### PR TITLE
Fixed errors and formatting in 11

### DIFF
--- a/C++/11Month-over-Month.cpp
+++ b/C++/11Month-over-Month.cpp
@@ -6,11 +6,11 @@ int main() {
     std::cout << "What's your name buddy: ";
     std::cin >> username;
 
-    std::cout << "Hello " << username;
+    std::cout << "Hello " << username << "\n\n";
     
     int month1;
     int month2;
-    int MoM;
+    float MoM;
     
     std::cout << "Enter the value for month 1 " << username << ": ";
     std::cin >> month1;
@@ -18,9 +18,11 @@ int main() {
     std::cin >> month2;
     
 
-    MoM = (month2 - month1)/(month1);
+    MoM = (month2 - month1);
+    MoM = MoM/(month1); // has to be seperate since month1, month2 are not floats; c++ is integer div by default so div by month1 has to be seperate
     MoM = MoM * 100;
     
-    std::cout << "The Month-over-month (MoM) is " << MoM;
+    std::cout << "The Month-over-Month (MoM) change is " << MoM << "%.\n";
+
     return 0;
 }


### PR DESCRIPTION
Problem 11 in c++ had integer division errors:

`// has to be seperate since month1, month2 are not floats; c++ is integer div by default so div by month1 has to be separate`